### PR TITLE
chown everything on image dir to cloud-user

### DIFF
--- a/roles/docker_host/tasks/mount_devices.yml
+++ b/roles/docker_host/tasks/mount_devices.yml
@@ -20,6 +20,7 @@
     state: directory
     owner: cloud-user
     group: cloud-user
+    recurse: true
   when: image_device is defined
   become: True
 


### PR DESCRIPTION
this is required so it is possible to upload images directly to the host as cloud-user and not have to upload them to tmp and move from there