### PR TITLE
use postgresql version independent package

### DIFF
--- a/roles/api/tasks/main.yml
+++ b/roles/api/tasks/main.yml
@@ -4,7 +4,7 @@
     pkg={{ item }}
     state=present
   with_items:
-    - postgresql-client-9.5
+    - postgresql-client
     - libpq-dev
     - python-psycopg2
 
@@ -13,7 +13,7 @@
     pkg={{ item }}
     state=present
   with_items:
-    - postgresql-9.5
+    - postgresql
     - libpq-dev
     - redis-server
   when: deploy_mode == "devel"


### PR DESCRIPTION
Drop the postgresql version from the package name and use
whatever is available in the distro.